### PR TITLE
merge optimizations about IMPORT ... FROM SELECT

### DIFF
--- a/pkg/executor/import_into.go
+++ b/pkg/executor/import_into.go
@@ -276,8 +276,8 @@ func (e *ImportIntoExec) importFromSelect(ctx context.Context) error {
 			logutil.Logger(ctx).Error("close importer failed", zap.Error(err))
 		}
 	}()
-	selectedRowCh := make(chan importer.QueryRow)
-	ti.SetSelectedRowCh(selectedRowCh)
+	selectedChunkCh := make(chan importer.QueryChunk, e.controller.ThreadCnt)
+	ti.SetSelectedChunkCh(selectedChunkCh)
 
 	var importResult *importer.JobImportResult
 	eg, egCtx := errgroup.WithContext(ctx)
@@ -287,13 +287,14 @@ func (e *ImportIntoExec) importFromSelect(ctx context.Context) error {
 		return err
 	})
 	eg.Go(func() error {
-		defer close(selectedRowCh)
+		defer close(selectedChunkCh)
 		fields := exec.RetTypes(e.selectExec)
+		chkSize := e.selectExec.InitCap()
+		maxChkSize := e.selectExec.MaxChunkSize()
 		var idAllocator int64
 		for {
 			// rows will be consumed concurrently, we cannot use chunk pool in session ctx.
-			chk := exec.NewFirstChunk(e.selectExec)
-			iter := chunk.NewIterator4Chunk(chk)
+			chk := chunk.New(e.selectExec.RetFieldTypes(), chkSize, maxChkSize)
 			err := exec.Next(egCtx, e.selectExec, chk)
 			if err != nil {
 				return err
@@ -301,16 +302,19 @@ func (e *ImportIntoExec) importFromSelect(ctx context.Context) error {
 			if chk.NumRows() == 0 {
 				break
 			}
-			for innerChunkRow := iter.Begin(); innerChunkRow != iter.End(); innerChunkRow = iter.Next() {
-				idAllocator++
-				select {
-				case selectedRowCh <- importer.QueryRow{
-					ID:   idAllocator,
-					Data: innerChunkRow.GetDatumRow(fields),
-				}:
-				case <-egCtx.Done():
-					return egCtx.Err()
-				}
+			select {
+			case selectedChunkCh <- importer.QueryChunk{
+				Fields: fields,
+				Chk:    chk,
+				Offset: idAllocator,
+			}:
+				idAllocator += int64(chk.NumRows())
+			case <-egCtx.Done():
+				return egCtx.Err()
+			}
+			if chkSize < maxChkSize {
+				chkSize = chkSize * 2
+				chkSize = min(chkSize, maxChkSize)
 			}
 		}
 		return nil

--- a/pkg/executor/importer/chunk_process.go
+++ b/pkg/executor/importer/chunk_process.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/syncutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -48,19 +49,20 @@ var (
 )
 
 type rowToEncode struct {
-	row   []types.Datum
-	rowID int64
+	row    []types.Datum
+	rowID  int64
+	fields []*types.FieldType
 	// endOffset represents the offset after the current row in encode reader.
 	// it will be negative if the data source is not file.
 	endOffset int64
 	resetFn   func()
 }
 
-type encodeReaderFn func(ctx context.Context) (data rowToEncode, closed bool, err error)
+type encodeReaderFn func(ctx context.Context, row []types.Datum) (data rowToEncode, closed bool, err error)
 
 // parserEncodeReader wraps a mydump.Parser as a encodeReaderFn.
 func parserEncodeReader(parser mydump.Parser, endOffset int64, filename string) encodeReaderFn {
-	return func(context.Context) (data rowToEncode, closed bool, err error) {
+	return func(context.Context, []types.Datum) (data rowToEncode, closed bool, err error) {
 		readPos, _ := parser.Pos()
 		if readPos >= endOffset {
 			closed = true
@@ -91,30 +93,64 @@ func parserEncodeReader(parser mydump.Parser, endOffset int64, filename string) 
 	}
 }
 
-// queryRowEncodeReader wraps a QueryRow channel as a encodeReaderFn.
-func queryRowEncodeReader(rowCh <-chan QueryRow) encodeReaderFn {
-	return func(ctx context.Context) (data rowToEncode, closed bool, err error) {
+type queryChunkEncodeReader struct {
+	chunkCh  <-chan QueryChunk
+	queryChk QueryChunk
+	cursor   int
+	numRows  int
+}
+
+func (r *queryChunkEncodeReader) readRow(ctx context.Context, row []types.Datum) (data rowToEncode, closed bool, err error) {
+	if r.queryChk.Chk == nil || r.cursor >= r.numRows {
 		select {
 		case <-ctx.Done():
 			err = ctx.Err()
 			return
-		case row, ok := <-rowCh:
+		case queryChk, ok := <-r.chunkCh:
 			if !ok {
 				closed = true
 				return
 			}
-			data = rowToEncode{
-				row:       row.Data,
-				rowID:     row.ID,
-				endOffset: -1,
-				resetFn:   func() {},
-			}
-			return
+			r.queryChk = queryChk
+			r.cursor = 0
+			r.numRows = r.queryChk.Chk.NumRows()
 		}
+	}
+
+	chkRow := r.queryChk.Chk.GetRow(r.cursor)
+	chkRow.Len()
+	rowLen := chkRow.Len()
+	if len(row) < rowLen {
+		row = make([]types.Datum, rowLen)
+	} else {
+		row = row[:rowLen]
+		for i := range row {
+			row[i] = types.Datum{}
+		}
+	}
+	row = chkRow.GetDatumRowWithBuffer(r.queryChk.Fields, row)
+
+	r.cursor++
+	data = rowToEncode{
+		row:       row,
+		rowID:     r.queryChk.Offset + int64(r.cursor),
+		fields:    r.queryChk.Fields,
+		endOffset: -1,
+		resetFn:   func() {},
+	}
+	return
+}
+
+// queryRowEncodeReader wraps a queryChunkEncodeReader as a encodeReaderFn.
+func queryRowEncodeReader(chunkCh <-chan QueryChunk) encodeReaderFn {
+	reader := queryChunkEncodeReader{chunkCh: chunkCh}
+	return func(ctx context.Context, row []types.Datum) (data rowToEncode, closed bool, err error) {
+		return reader.readRow(ctx, row)
 	}
 }
 
 type encodedKVGroupBatch struct {
+	count    int
 	dataKVs  []common.KvPair
 	indexKVs map[int64][]common.KvPair // indexID -> pairs
 
@@ -134,8 +170,10 @@ func (b *encodedKVGroupBatch) reset() {
 	b.memBuf = nil
 }
 
-func newEncodedKVGroupBatch(keyspace []byte) *encodedKVGroupBatch {
+func newEncodedKVGroupBatch(keyspace []byte, count int) *encodedKVGroupBatch {
 	return &encodedKVGroupBatch{
+		count:         count,
+		dataKVs:       make([]common.KvPair, 0, count),
 		indexKVs:      make(map[int64][]common.KvPair, 8),
 		groupChecksum: verify.NewKVGroupChecksumWithKeyspace(keyspace),
 	}
@@ -146,14 +184,21 @@ func (b *encodedKVGroupBatch) add(kvs *kv.Pairs) error {
 	for _, pair := range kvs.Pairs {
 		if tablecodec.IsRecordKey(pair.Key) {
 			b.dataKVs = append(b.dataKVs, pair)
-			b.groupChecksum.UpdateOneDataKV(pair)
+			if b.groupChecksum != nil {
+				b.groupChecksum.UpdateOneDataKV(pair)
+			}
 		} else {
 			indexID, err := tablecodec.DecodeIndexID(pair.Key)
 			if err != nil {
 				return errors.Trace(err)
 			}
+			if len(b.indexKVs[indexID]) == 0 {
+				b.indexKVs[indexID] = make([]common.KvPair, 0, b.count)
+			}
 			b.indexKVs[indexID] = append(b.indexKVs[indexID], pair)
-			b.groupChecksum.UpdateOneIndexKV(indexID, pair)
+			if b.groupChecksum != nil {
+				b.groupChecksum.UpdateOneIndexKV(indexID, pair)
+			}
 		}
 	}
 
@@ -242,15 +287,28 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 		p.encodeTotalDur += encodeDur
 		p.readTotalDur += readDur
 
-		kvGroupBatch := newEncodedKVGroupBatch(p.keyspace)
+		recordCount := 0
+		for _, kvs := range rowBatch {
+			for _, pair := range kvs.Pairs {
+				if tablecodec.IsRecordKey(pair.Key) {
+					recordCount++
+					break
+				}
+			}
+		}
+		kvGroupBatch := newEncodedKVGroupBatch(p.keyspace, recordCount)
+		if p.groupChecksum == nil {
+			kvGroupBatch.groupChecksum = nil
+		}
 
 		for _, kvs := range rowBatch {
 			if err := kvGroupBatch.add(kvs); err != nil {
 				return errors.Trace(err)
 			}
 		}
-
-		p.groupChecksum.Add(kvGroupBatch.groupChecksum)
+		if p.groupChecksum != nil {
+			p.groupChecksum.Add(kvGroupBatch.groupChecksum)
+		}
 
 		if err := p.sendFn(ctx, kvGroupBatch); err != nil {
 			return err
@@ -258,7 +316,7 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 
 		// the ownership of rowBatch is transferred to the receiver of sendFn, we should
 		// not touch it anymore.
-		rowBatch = make([]*kv.Pairs, 0, MinDeliverRowCnt)
+		rowBatch = make([]*kv.Pairs, 0, max(MinDeliverRowCnt, len(rowBatch)))
 		rowBatchByteSize = 0
 		rowCount = 0
 		readDur = 0
@@ -266,9 +324,10 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 		return nil
 	}
 
+	var readRowCache []types.Datum
 	for {
 		readDurStart := time.Now()
-		data, closed, err := p.readFn(ctx)
+		data, closed, err := p.readFn(ctx, readRowCache)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -278,7 +337,7 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 		readDur += time.Since(readDurStart)
 
 		encodeDurStart := time.Now()
-		kvs, encodeErr := p.encoder.Encode(data.row, data.rowID)
+		kvs, encodeErr := p.encoder.Encode(data.row, data.rowID, data.fields)
 		currOffset = data.endOffset
 		data.resetFn()
 		if encodeErr != nil {
@@ -298,13 +357,17 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 				return err
 			}
 		}
+		readRowCache = data.row
 	}
 
 	return recordSendReset()
 }
 
 func (p *chunkEncoder) summaryFields() []zap.Field {
-	mergedChecksum := p.groupChecksum.MergedChecksum()
+	var mergedChecksum verify.KVChecksum
+	if p.groupChecksum != nil {
+		mergedChecksum = p.groupChecksum.MergedChecksum()
+	}
 	return []zap.Field{
 		zap.Duration("readDur", p.readTotalDur),
 		zap.Duration("encodeDur", p.encodeTotalDur),
@@ -469,8 +532,16 @@ func (p *dataDeliver) deliverLoop(ctx context.Context) error {
 			if metrics != nil {
 				metrics.BlockDeliverSecondsHistogram.Observe(deliverDur.Seconds())
 
-				dataSize, indexSize := kvBatch.groupChecksum.DataAndIndexSumSize()
-				dataKVCnt, indexKVCnt := kvBatch.groupChecksum.DataAndIndexSumKVS()
+				var (
+					dataSize, indexSize   uint64
+					dataKVCnt, indexKVCnt uint64
+				)
+
+				if kvBatch.groupChecksum != nil {
+					dataSize, indexSize = kvBatch.groupChecksum.DataAndIndexSumSize()
+					dataKVCnt, indexKVCnt = kvBatch.groupChecksum.DataAndIndexSumKVS()
+				}
+
 				dataKVBytesHist.Observe(float64(dataSize))
 				dataKVPairsHist.Observe(float64(dataKVCnt))
 				indexKVBytesHist.Observe(float64(indexSize))
@@ -493,14 +564,15 @@ func (p *dataDeliver) summaryFields() []zap.Field {
 	}
 }
 
-// QueryRow is a row from query result.
-type QueryRow struct {
-	ID   int64
-	Data []types.Datum
+// QueryChunk is a chunk from query result.
+type QueryChunk struct {
+	Fields []*types.FieldType
+	Chk    *chunk.Chunk
+	Offset int64
 }
 
 func newQueryChunkProcessor(
-	rowCh chan QueryRow,
+	chunkCh chan QueryChunk,
 	encoder KVEncoder,
 	keyspace []byte,
 	logger *zap.Logger,
@@ -518,18 +590,22 @@ func newQueryChunkProcessor(
 		dataWriter:    dataWriter,
 		indexWriter:   indexWriter,
 	}
+	enc := newChunkEncoder(
+		chunkName,
+		queryRowEncodeReader(chunkCh),
+		-1,
+		deliver.sendEncodedData,
+		chunkLogger,
+		encoder,
+		keyspace,
+	)
+	if groupChecksum == nil {
+		enc.groupChecksum = nil
+	}
 	return &baseChunkProcessor{
-		sourceType: DataSourceTypeQuery,
-		deliver:    deliver,
-		enc: newChunkEncoder(
-			chunkName,
-			queryRowEncodeReader(rowCh),
-			-1,
-			deliver.sendEncodedData,
-			chunkLogger,
-			encoder,
-			keyspace,
-		),
+		sourceType:    DataSourceTypeQuery,
+		deliver:       deliver,
+		enc:           enc,
 		logger:        chunkLogger,
 		groupChecksum: groupChecksum,
 	}

--- a/pkg/executor/importer/engine_process.go
+++ b/pkg/executor/importer/engine_process.go
@@ -108,7 +108,7 @@ func ProcessChunkWithWriter(
 		)
 	case DataSourceTypeQuery:
 		cp = newQueryChunkProcessor(
-			tableImporter.rowCh, encoder, tableImporter.GetKeySpace(), logger,
+			tableImporter.chunkCh, encoder, tableImporter.GetKeySpace(), logger,
 			tableImporter.diskQuotaLock, dataWriter, indexWriter, groupChecksum,
 		)
 	}

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -142,6 +142,7 @@ var (
 	allowedOptionsOfImportFromQuery = map[string]struct{}{
 		threadOption:          {},
 		disablePrecheckOption: {},
+		checksumTableOption:   {},
 	}
 
 	// LoadDataReadBlockSize is exposed for test.

--- a/pkg/executor/importer/importer_testkit_test.go
+++ b/pkg/executor/importer/importer_testkit_test.go
@@ -331,9 +331,9 @@ func TestProcessChunkWith(t *testing.T) {
 		}
 		ti := getTableImporter(ctx, t, store, "t", "", nil)
 		defer ti.Backend().CloseEngineMgr()
-		rowsCh := make(chan importer.QueryRow, 3)
+		chkCh := make(chan importer.QueryChunk, 3)
 		for i := 1; i <= 3; i++ {
-			rowsCh <- importer.QueryRow{
+			chkCh <- importer.QueryChunk{
 				ID: int64(i),
 				Data: []types.Datum{
 					types.NewIntDatum(int64((i-1)*3 + 1)),
@@ -342,8 +342,8 @@ func TestProcessChunkWith(t *testing.T) {
 				},
 			}
 		}
-		close(rowsCh)
-		ti.SetSelectedRowCh(rowsCh)
+		close(chkCh)
+		ti.SetSelectedChunkCh(chkCh)
 		kvWriter := mock.NewMockEngineWriter(ctrl)
 		kvWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		progress := importer.NewProgress()

--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -69,8 +69,11 @@ func (e *LoadDataController) CheckRequirements(ctx context.Context, conn sqlexec
 			return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("global sort requires at least 8 threads")
 		}
 	}
-	if err := e.checkTableEmpty(ctx, conn); err != nil {
-		return err
+	// only for poc
+	if !e.DisablePrecheck {
+		if err := e.checkTableEmpty(ctx, conn); err != nil {
+			return err
+		}
 	}
 	if !e.DisablePrecheck {
 		if err := e.checkCDCPiTRTasks(ctx); err != nil {

--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -118,6 +118,12 @@ func TestCheckRequirements(t *testing.T) {
 	_, err = conn.Execute(ctx, "insert into test.t values(1)")
 	require.NoError(t, err)
 	require.ErrorIs(t, c.CheckRequirements(ctx, conn), exeerrors.ErrLoadDataPreCheckFailed)
+
+	// disable precheck, should pass
+	c.DisablePrecheck = true
+	require.NoError(t, c.CheckRequirements(ctx, conn))
+	c.DisablePrecheck = false // revert back
+
 	// table not exists
 	_, err = conn.Execute(ctx, "drop table if exists test.t")
 	require.NoError(t, err)

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -229,7 +229,7 @@ type TableImporter struct {
 	diskQuota       int64
 	diskQuotaLock   *syncutil.RWMutex
 
-	rowCh chan QueryRow
+	chunkCh chan QueryChunk
 }
 
 // NewTableImporterForTest creates a new table importer for test.
@@ -604,9 +604,9 @@ func (ti *TableImporter) CheckDiskQuota(ctx context.Context) {
 	}
 }
 
-// SetSelectedRowCh sets the channel to receive selected rows.
-func (ti *TableImporter) SetSelectedRowCh(ch chan QueryRow) {
-	ti.rowCh = ch
+// SetSelectedChunkCh sets the channel to receive selected rows.
+func (ti *TableImporter) SetSelectedChunkCh(ch chan QueryChunk) {
+	ti.chunkCh = ch
 }
 
 func (ti *TableImporter) closeAndCleanupEngine(engine *backend.OpenedEngine) {
@@ -662,12 +662,17 @@ func (ti *TableImporter) ImportSelectedRows(ctx context.Context, se sessionctx.C
 	for i := 0; i < ti.ThreadCnt; i++ {
 		eg.Go(func() error {
 			chunkCheckpoint := checkpoints.ChunkCheckpoint{}
-			chunkChecksum := verify.NewKVGroupChecksumWithKeyspace(ti.keyspace)
+			var chunkChecksum *verify.KVGroupChecksum
+			if ti.Checksum != config.OpLevelOff {
+				chunkChecksum = verify.NewKVGroupChecksumWithKeyspace(ti.keyspace)
+			}
 			progress := NewProgress()
 			defer func() {
 				mu.Lock()
 				defer mu.Unlock()
-				checksum.Add(chunkChecksum)
+				if chunkChecksum != nil {
+					checksum.Add(chunkChecksum)
+				}
 				for k, v := range progress.GetColSize() {
 					colSizeMap[k] += v
 				}

--- a/pkg/executor/importer/table_import_testkit_test.go
+++ b/pkg/executor/importer/table_import_testkit_test.go
@@ -106,13 +106,13 @@ func TestImportFromSelectCleanup(t *testing.T) {
 		&storeHelper{kvStore: store},
 	)
 	require.NoError(t, err)
-	ch := make(chan importer.QueryRow)
-	ti.SetSelectedRowCh(ch)
+	ch := make(chan importer.QueryChunk)
+	ti.SetSelectedChunkCh(ch)
 	var wg util.WaitGroupWrapper
 	wg.Run(func() {
 		defer close(ch)
 		for i := 1; i <= 3; i++ {
-			ch <- importer.QueryRow{
+			ch <- importer.QueryChunk{
 				ID: int64(i),
 				Data: []types.Datum{
 					types.NewIntDatum(int64(i)),

--- a/pkg/lightning/backend/kv/base.go
+++ b/pkg/lightning/backend/kv/base.go
@@ -223,8 +223,8 @@ func (e *BaseKVEncoder) TableMeta() *model.TableInfo {
 }
 
 // ProcessColDatum processes the datum of a column.
-func (e *BaseKVEncoder) ProcessColDatum(col *table.Column, rowID int64, inputDatum *types.Datum) (types.Datum, error) {
-	value, err := e.getActualDatum(col, rowID, inputDatum)
+func (e *BaseKVEncoder) ProcessColDatum(col *table.Column, rowID int64, inputDatum *types.Datum, needCast bool) (types.Datum, error) {
+	value, err := e.getActualDatum(col, rowID, inputDatum, needCast)
 	if err != nil {
 		return value, err
 	}
@@ -248,7 +248,7 @@ func (e *BaseKVEncoder) ProcessColDatum(col *table.Column, rowID int64, inputDat
 	return value, nil
 }
 
-func (e *BaseKVEncoder) getActualDatum(col *table.Column, rowID int64, inputDatum *types.Datum) (types.Datum, error) {
+func (e *BaseKVEncoder) getActualDatum(col *table.Column, rowID int64, inputDatum *types.Datum, needCast bool) (types.Datum, error) {
 	var (
 		value types.Datum
 		err   error
@@ -258,9 +258,13 @@ func (e *BaseKVEncoder) getActualDatum(col *table.Column, rowID int64, inputDatu
 	exprCtx := e.SessionCtx.GetExprCtx()
 	errCtx := exprCtx.GetEvalCtx().ErrCtx()
 	if inputDatum != nil {
-		value, err = table.CastColumnValue(exprCtx, *inputDatum, col.ToInfo(), false, false)
-		if err != nil {
-			return value, err
+		if needCast {
+			value, err = table.CastColumnValue(exprCtx, *inputDatum, col.ToInfo(), false, false)
+			if err != nil {
+				return value, err
+			}
+		} else {
+			value = *inputDatum
 		}
 		if err := col.CheckNotNull(&value, 0); err == nil {
 			return value, nil // the most normal case

--- a/pkg/lightning/backend/kv/sql2kv.go
+++ b/pkg/lightning/backend/kv/sql2kv.go
@@ -230,7 +230,7 @@ func (kvcodec *tableKVEncoder) Encode(row []types.Datum,
 		if j >= 0 && j < len(row) {
 			theDatum = &row[j]
 		}
-		value, err = kvcodec.ProcessColDatum(col, rowID, theDatum)
+		value, err = kvcodec.ProcessColDatum(col, rowID, theDatum, true)
 		if err != nil {
 			return nil, kvcodec.LogKVConvertFailed(row, j, col.ToInfo(), err)
 		}
@@ -286,7 +286,7 @@ func GetEncoderSe(encoder encode.Encoder) *Session {
 // GetActualDatum export getActualDatum function.
 func GetActualDatum(encoder encode.Encoder, col *table.Column, rowID int64,
 	inputDatum *types.Datum) (types.Datum, error) {
-	return encoder.(*tableKVEncoder).getActualDatum(col, rowID, inputDatum)
+	return encoder.(*tableKVEncoder).getActualDatum(col, rowID, inputDatum, true)
 }
 
 // GetAutoRecordID returns the record ID for an auto-increment field.

--- a/tests/realtikvtest/importintotest2/from_select_test.go
+++ b/tests/realtikvtest/importintotest2/from_select_test.go
@@ -155,3 +155,27 @@ func (s *mockGCSSuite) TestImportFromSelectStaleRead() {
 	s.tk.MustExec("import into dst from " + staleReadSQL)
 	s.tk.MustQuery("select * from dst").Check(testkit.Rows("1 a", "2 b"))
 }
+
+func (s *mockGCSSuite) TestImportFromSelectNonEmpty() {
+	s.prepareAndUseDB("from_select")
+	s.tk.MustExec("create table src1(id int, v varchar(64), primary key(id))")
+	s.tk.MustExec("insert into src1 values(4, 'aaaaaa'), (5, 'bbbbbb'), (6, 'cccccc'), (7, 'dddddd')")
+	s.tk.MustExec("create table src2(id int, v varchar(64), primary key(id))")
+	s.tk.MustExec("insert into src2 values(8, 'aaaaaa'), (9, 'bbbbbb'), (10, 'cccccc'), (11, 'dddddd')")
+	s.tk.MustExec("create table dst(id int, v varchar(64), primary key(id))")
+
+	s.ErrorIs(s.tk.ExecToErr(`import into dst FROM select id from src1`), plannererrors.ErrWrongValueCountOnRow)
+	s.ErrorIs(s.tk.ExecToErr(`import into dst(id) FROM select * from src1`), plannererrors.ErrWrongValueCountOnRow)
+
+	s.tk.MustExec(`import into dst FROM select * from src1`)
+	s.Equal(uint64(4), s.tk.Session().GetSessionVars().StmtCtx.AffectedRows())
+	s.Contains(s.tk.Session().LastMessage(), "Records: 4,")
+	s.tk.MustQuery("select * from dst").Check(testkit.Rows("4 aaaaaa", "5 bbbbbb", "6 cccccc", "7 dddddd"))
+
+	// non-empty table
+	s.ErrorContains(s.tk.ExecToErr(`import into dst FROM select * from src2`), "target table is not empty")
+	s.tk.MustExec(`import into dst FROM select * from src2 with disable_precheck, checksum_table='false'`)
+	s.Equal(uint64(4), s.tk.Session().GetSessionVars().StmtCtx.AffectedRows())
+	s.Contains(s.tk.Session().LastMessage(), "Records: 4,")
+	s.tk.MustQuery("select * from dst").Sort().Check(testkit.Rows("10 cccccc", "11 dddddd", "4 aaaaaa", "5 bbbbbb", "6 cccccc", "7 dddddd", "8 aaaaaa", "9 bbbbbb"))
+}


### PR DESCRIPTION
    - avoid useless alocate
    - skip more checksum
    - enlarge channel size
    - avoid duplicate cast column value and add cache and pre-allocate to avoid runtime.makeslice
    - executor: tiny optimize import into from select performance
    - importer: add table_checksum option for import from select (#58428)
      - close pingcap/tidb#58417
    - importer: disable_precheck allows skipping of table empty check (#58422) - ref pingcap/tidb#49883, ref pingcap/tidb#58417

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
